### PR TITLE
blakerc_codereview

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/app/src/main/java/edu/uc/kovaciad/slicetracker/dto/SliceFile.kt
+++ b/app/src/main/java/edu/uc/kovaciad/slicetracker/dto/SliceFile.kt
@@ -1,6 +1,8 @@
 package edu.uc.kovaciad.slicetracker.dto
 
 import android.text.format.Time
+//as of api 22 Time is depreciated and it is suggested to use GregorianCalendar
+import java.util.GregorianCalendar
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -37,6 +39,7 @@ data class SliceFile (@PrimaryKey var sfid: Int,
                       @ColumnInfo(name = "resinLiftHeight") var resinLiftHeight : Int = 0,
                       @ColumnInfo(name = "numberOfLayers") var numberOfLayers : Int = 0,
                       @ColumnInfo(name = "filamentNozzleThickness") var filamentNozzleThickness : Double = 0.0,
+                      //Time should be changed with GregorianCalander (I dont want to mess up your DB so i wont make this change)
                       @ColumnInfo(name = "filamentNozzleEstimatedTime") var filamentNozzleEstimatedTime : Time,
                       @ColumnInfo(name = "filamentEstimatedMaterial") var filamentEstimatedMaterial : Double = 0.0)
 {


### PR DESCRIPTION
Analysis of the program. : This program seems to be made to organize your slice files for 3d printing. This is something that I didn't realize was a problem, but now that I think about it, makes a lot of sense.

Was the program available in UC Github on time? Yes

Is the program documented/commented well enough for you to understand? Yes the program makes a lot of sense and has a VERY well written back-end so far, the DTO's and DAO,s are structured in very understandable and logical ways

Does the program compile? Yes

Rationale behind your changes. There was very little changes that needed to be done, the only thing I could find was that they were using android.text.format.Time, which is actually depreciated as of API 22 and should be replaced with calendar or GregorianCalander, this will also allow for better access to functions revolving around the time column

Links to three specific commits that you made to your own group's GitHub repository before the end of sprint deadline.

https://github.com/Blakerc/MobileMeetings/commit/fd0919c1d0f03b15d1b5ed48fbed128d2e9a012a
https://github.com/Blakerc/MobileMeetings/commit/6424eafeb06b1b48f1a82d179ebbecaecad4a73a
https://github.com/Blakerc/MobileMeetings/commit/28381000433ebd4a4053f987e3a3e9d901678957

 
Next, list three specific technical concepts that you learned from this code review.  Copy and paste samples to demonstrate your point.  Examples:

  1. in their SliceFile.kt they show a great example of setting up a table with a PK and all of the columns, this is something i haven't done yet, but from what i can tell this is a very good example

@Entity(tableName = "SliceFile")
data class SliceFile (@PrimaryKey var sfid: Int,
                      @ColumnInfo(name = "sliceFileName") var sliceFileName : String,
                      @ColumnInfo(name = "modelId") var modelId : Int,

================

2. in the MainFragment they get the data ready to be loaded into autocompletes, this seems to be a streamlined way to do it, and different then how I've done it in the past

        applicationViewModel.printerService.getPrinterDAO().getAll().observe(viewLifecycleOwner, Observer {
//                printers ->
        })

===================

3. even though it's commented out, it's cool to see this test, which uses @before and @after to test if the SQL db has started ok

//    private lateinit var db: SliceDatabase
//    @Before
//    fun createDb() {
//        val context = ApplicationProvider.getApplicationContext<Context>()
//        db = Room.databaseBuilder(
//            context,
//            SliceDatabase::class.java, "main-db"
//        ).build()
//    }
//
////    @After
////    @Throws(IOException::class)
////    fun closeDb() {
////        db.close()
////    }

