### PR TITLE
My Code Review Changes

### DIFF
--- a/app/src/androidTest/java/edu/uc/kovaciad/slicetracker/SQLInitTest.kt
+++ b/app/src/androidTest/java/edu/uc/kovaciad/slicetracker/SQLInitTest.kt
@@ -22,7 +22,7 @@ import java.sql.SQLException
 @RunWith(AndroidJUnit4::class)
 class SQLInitTest {
 //
-//    private lateinit var db: SliceDatabase
+//    private lateinit val db: SliceDatabase
 //    @Before
 //    fun createDb() {
 //        val context = ApplicationProvider.getApplicationContext<Context>()

--- a/app/src/main/java/edu/uc/kovaciad/slicetracker/dao/SliceDatabase.kt
+++ b/app/src/main/java/edu/uc/kovaciad/slicetracker/dao/SliceDatabase.kt
@@ -6,10 +6,10 @@ import edu.uc.kovaciad.slicetracker.dto.Material
 import edu.uc.kovaciad.slicetracker.dto.Model
 import edu.uc.kovaciad.slicetracker.dto.Printer
 
-@Database(entities = arrayOf(Brand::class, Material::class, Model::class, Printer::class), version=1)
+@Database(entities = [Brand::class, Material::class, Model::class, Printer::class], version=1)
 abstract class SliceDatabase : RoomDatabase() {
     abstract fun printerDao(): IPrinterDAO
-//    abstract fun materialDao(): IMaterialDAO
+    abstract fun materialDao(): IMaterialDAO
     abstract fun modelDao(): IModelDAO
     abstract fun brandDao(): IBrandDAO
 }

--- a/app/src/main/java/edu/uc/kovaciad/slicetracker/dto/Brand.kt
+++ b/app/src/main/java/edu/uc/kovaciad/slicetracker/dto/Brand.kt
@@ -7,6 +7,7 @@ import androidx.room.PrimaryKey
 /**
  * @param bid: DB ID for dev use
  * @param brandName: User Inputted Name
+ * @param brandUrl: Brand URL
  */
 @Entity(tableName = "Brand")
 data class Brand(@PrimaryKey val bid: Int,

--- a/app/src/main/java/edu/uc/kovaciad/slicetracker/services/MaterialService.kt
+++ b/app/src/main/java/edu/uc/kovaciad/slicetracker/services/MaterialService.kt
@@ -2,17 +2,17 @@ package edu.uc.kovaciad.slicetracker.services
 
 import android.app.Application
 import androidx.room.Room
-import edu.uc.kovaciad.slicetracker.dao.IBrandDAO
+import edu.uc.kovaciad.slicetracker.dao.IMaterialDAO
 import edu.uc.kovaciad.slicetracker.dao.SliceDatabase
 
-//class MaterialService(application: Application) {
-//    private val application = application
-//
-//    internal fun getMaterialDAO(): IMaterialDAO {
-//        val db = Room.databaseBuilder(
-//            application,
-//            SliceDatabase::class.java, "mat-db"
-//        ).build()
-//        val materialDAO = db.materialDao()
-//        return materialDAO
-//}
+class MaterialService(application: Application) {
+    private val application = application
+
+    internal fun getMaterialDAO(): IMaterialDAO {
+        val db = Room.databaseBuilder(
+            application,
+            SliceDatabase::class.java, "mat-db"
+        ).build()
+        return db.materialDao()
+    }
+}

--- a/app/src/main/java/edu/uc/kovaciad/slicetracker/ui/main/MainFragment.kt
+++ b/app/src/main/java/edu/uc/kovaciad/slicetracker/ui/main/MainFragment.kt
@@ -21,7 +21,8 @@ class MainFragment : Fragment() {
 //    private lateinit var applicationViewModel: ApplicationViewModel
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         return inflater.inflate(R.layout.main_fragment, container, false)


### PR DESCRIPTION
### Analysis, Availability, and Compilation
This program utilizes RoomDB for storing various slice files relevant to 3D printing, as well as keeping track of estimated times to print the stored files. The groundwork has been laid for the database, as well as it's interactions such as adding and deleting entries. Though it has yet to be finished with these features. Regardless, the project was available on time for me to begin code review in a compiliable state.


### Documentation
The program's documentation was not bad. Several classes that create tables such as Material.kt thouroughly described each column in the table (Columns were in the form of variables). However, classes such as MainActivity.kt and MaterialService.kt sported zero documentation and were thus harder to understand on ocassion.

### Personal GitHub Commits
My own Github commits (Includes commits from old and new repositories):

- https://github.com/HowardH1/Pool-Testing-System/commit/9d6aee8c9a721070a3faee5b350916d91b1ec99c
- https://github.com/HowardH1/Pool-Testing-System/commit/384fc0e56846d2d326e7d2fe1c14d138de86e964
- https://github.com/shxmbles/PoolTest/commit/29e338cc3c1230533c228cc122aadbe328ccf001

### Technical Learning
I was extremely interested in what I learned from the project as I work with a similar concept to RoomDB at my job. Thus most of what I picked up revolved around the package, such as:

**How to create and structure a table in Kotlin using RoomDB** 
@Entity(tableName = "Table") 
data class Table (@PrimaryKey var PK: Int,
                                @ColumnInfo(name = "column") var column: String

**How to use created classes to form a database** 
@Database(entities = [Table1::class, Table2::class], version=1))
abstract class Database : RoomDatabase() {
    abstract fun tableDao(): ITableDAO
    abstract fun table2Dao(): ITable2DAO
}

**Structure for utilizing SQL statements to make queries on the database** 
_db.execSQL("CREATE TABLE IF NOT EXISTS `kotlinVariable`) 